### PR TITLE
refactor notification and enrollment ID capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ KMFDDM=\
 
 SUPPLEMENTAL=\
 	tools/*.sh \
-	tools/ideclr.py
+	tools/*.py
 
 my: kmfddm-$(OSARCH)
 

--- a/cmd/kmfddm/main.go
+++ b/cmd/kmfddm/main.go
@@ -226,6 +226,13 @@ func main() {
 				apihttp.GetStatusValuesHandler(storage, logger.With("handler", "get-status-values")),
 				"GET",
 			)
+
+			// notifier
+			mux.Handle(
+				"/v1/notify",
+				apihttp.NotifyHandler(nanoNotif, logger.With("handler", "notify")),
+				"POST",
+			)
 		})
 	}
 

--- a/cmd/kmfddm/storage.go
+++ b/cmd/kmfddm/storage.go
@@ -17,13 +17,13 @@ import (
 type allStorage interface {
 	api.SetAPIStorage
 	api.DeclarationAPIStorage
-	ddm.DeclarationRetriever
-	ddm.TokensDeclarationItemsRetriever
 	ddm.StatusStorage
 	api.EnrollmentAPIStorage
 	api.StatusAPIStorage
 	storage.Toucher
 	storage.EnrollmentIDRetriever
+	storage.DeclarationRetriever
+	storage.TokensDeclarationItemsRetriever
 }
 
 var hasher func() hash.Hash = func() hash.Hash { return xxhash.New() }

--- a/cmd/kmfddm/storage.go
+++ b/cmd/kmfddm/storage.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cespare/xxhash"
 	"github.com/jessepeterson/kmfddm/http/api"
 	"github.com/jessepeterson/kmfddm/http/ddm"
-	"github.com/jessepeterson/kmfddm/notifier"
 	"github.com/jessepeterson/kmfddm/storage"
 	"github.com/jessepeterson/kmfddm/storage/file"
 	"github.com/jessepeterson/kmfddm/storage/mysql"
@@ -16,7 +15,6 @@ import (
 )
 
 type allStorage interface {
-	notifier.EnrollmentIDFinder
 	api.SetAPIStorage
 	api.DeclarationAPIStorage
 	ddm.DeclarationRetriever
@@ -25,6 +23,7 @@ type allStorage interface {
 	api.EnrollmentAPIStorage
 	api.StatusAPIStorage
 	storage.Toucher
+	storage.EnrollmentIDRetriever
 }
 
 var hasher func() hash.Hash = func() hash.Hash { return xxhash.New() }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -35,6 +35,43 @@ paths:
            $ref: '#/components/responses/JSONError'
     parameters:
       - $ref: '#/components/parameters/declarationID'
+  /v1/notify:
+    post:
+      description: Notify enrollment IDs by their ID or the sets they belong to, or, transitively, the declaration those sets are assigned.
+      security:
+        - basicAuth: []
+      responses:
+        '204':
+          description: Notification request received. See server logs for result (notification may be async).
+        '401':
+           $ref: '#/components/responses/UnauthorizedError'
+        '500':
+           $ref: '#/components/responses/JSONError'
+      parameters:
+        - in: query
+          name: declaration
+          schema:
+            type: array
+            items:
+              type: string
+          example: ['com.example.test']
+          explode: true
+        - in: query
+          name: set
+          schema:
+            type: array
+            items:
+              type: string
+          example: ['default']
+          explode: true
+        - in: query
+          name: id
+          schema:
+            type: array
+            items:
+              type: string
+          example: ['4A80F3DA-2738-434D-B95C-856811130F3B']
+          explode: true
 components:
   parameters:
     declarationID:

--- a/http/api/api.go
+++ b/http/api/api.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/alexedwards/flow"
 	"github.com/jessepeterson/kmfddm/log"
@@ -43,6 +44,18 @@ func jsonErrorAndLog(w http.ResponseWriter, status int, err error, msg string, l
 	}
 }
 
+func boolish(s string) bool {
+	switch strings.ToLower(s) {
+	case "", "0", "false", "no", "off":
+		return false
+	}
+	return true
+}
+
+func shouldNotify(u *url.URL) bool {
+	return !boolish(u.Query().Get("nonotify"))
+}
+
 func simpleJSONResourceHandler(logger log.Logger, dataFn func(context.Context, string, *url.URL) (interface{}, error)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := ctxlog.Logger(r.Context(), logger)
@@ -78,7 +91,7 @@ func simpleJSONResourceHandler(logger log.Logger, dataFn func(context.Context, s
 	}
 }
 
-func simpleChangeResourceHandler(logger log.Logger, chgFn func(context.Context, string, *url.URL) (bool, error)) http.HandlerFunc {
+func simpleChangeResourceHandler(logger log.Logger, chgFn func(context.Context, string, *url.URL, bool) (bool, string, error)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := ctxlog.Logger(r.Context(), logger)
 		var err error
@@ -94,10 +107,18 @@ func simpleChangeResourceHandler(logger log.Logger, chgFn func(context.Context, 
 			jsonErrorAndLog(w, http.StatusInternalServerError, err, "validating input", logger)
 			return
 		}
-		changed, err := chgFn(r.Context(), resource, r.URL)
+		notify := shouldNotify(r.URL)
+		changed, dataName, err := chgFn(r.Context(), resource, r.URL, notify)
+		chFnLogger := logger.With("msg", dataName, "changed", changed, "notify", changed && notify)
 		if err != nil {
-			jsonErrorAndLog(w, http.StatusInternalServerError, err, "retrieving data", logger)
+			chFnLogger.Info("err", err)
+			err = jsonError(w, http.StatusInternalServerError, err)
+			if err != nil {
+				logger.Info("msg", "writing response json", "err", err)
+			}
 			return
+		} else {
+			chFnLogger.Debug()
 		}
 		status := http.StatusNotModified
 		if changed {

--- a/http/api/api.go
+++ b/http/api/api.go
@@ -113,7 +113,5 @@ func getResourceID(r *http.Request) string {
 }
 
 type Notifier interface {
-	DeclarationChanged(ctx context.Context, identifier string) error
-	EnrollmentChanged(ctx context.Context, enrollID string) error
-	SetChanged(ctx context.Context, setName string) error
+	Changed(ctx context.Context, declarations []string, sets []string, ids []string) error
 }

--- a/http/api/declarations.go
+++ b/http/api/declarations.go
@@ -55,7 +55,7 @@ func PutDeclarationHandler(store DeclarationAPIStorage, notifier Notifier, logge
 		}
 		http.Error(w, http.StatusText(status), status)
 		if changed {
-			err = notifier.DeclarationChanged(r.Context(), d.Identifier)
+			err = notifier.Changed(r.Context(), []string{d.Identifier}, nil, nil)
 			if err != nil {
 				logger.Info("msg", "notifying", "err", err)
 				return
@@ -169,7 +169,7 @@ func TouchDeclarationHandler(store storage.Toucher, notifier Notifier, logger lo
 			return
 		}
 		http.Error(w, http.StatusText(http.StatusNoContent), http.StatusNoContent)
-		err = notifier.DeclarationChanged(r.Context(), declarationID)
+		err = notifier.Changed(r.Context(), []string{declarationID}, nil, nil)
 		if err != nil {
 			logger.Info("msg", "notifying", "err", err)
 			return

--- a/http/api/declarations.go
+++ b/http/api/declarations.go
@@ -48,13 +48,14 @@ func PutDeclarationHandler(store DeclarationAPIStorage, notifier Notifier, logge
 			jsonErrorAndLog(w, 0, err, "storing declaration", logger)
 			return
 		}
-		logger.Debug("msg", "stored declaration", "changed", changed)
+		notify := shouldNotify(r.URL)
+		logger.Debug("msg", "stored declaration", "changed", changed, "notify", changed && notify)
 		status := http.StatusNotModified
 		if changed {
 			status = http.StatusNoContent
 		}
 		http.Error(w, http.StatusText(status), status)
-		if changed {
+		if changed && notify {
 			err = notifier.Changed(r.Context(), []string{d.Identifier}, nil, nil)
 			if err != nil {
 				logger.Info("msg", "notifying", "err", err)
@@ -169,10 +170,14 @@ func TouchDeclarationHandler(store storage.Toucher, notifier Notifier, logger lo
 			return
 		}
 		http.Error(w, http.StatusText(http.StatusNoContent), http.StatusNoContent)
-		err = notifier.Changed(r.Context(), []string{declarationID}, nil, nil)
-		if err != nil {
-			logger.Info("msg", "notifying", "err", err)
-			return
+		notify := shouldNotify(r.URL)
+		logger.Debug("msg", "touched declaration", "notify", notify)
+		if notify {
+			err = notifier.Changed(r.Context(), []string{declarationID}, nil, nil)
+			if err != nil {
+				logger.Info("msg", "notifying", "err", err)
+				return
+			}
 		}
 	}
 }

--- a/http/api/enrollments.go
+++ b/http/api/enrollments.go
@@ -34,19 +34,19 @@ func GetEnrollmentSetsHandler(store EnrollmentAPIStorage, logger log.Logger) htt
 func PutEnrollmentSetHandler(store EnrollmentAPIStorage, notifier Notifier, logger log.Logger) http.HandlerFunc {
 	return simpleChangeResourceHandler(
 		logger,
-		func(ctx context.Context, resource string, u *url.URL) (bool, error) {
+		func(ctx context.Context, resource string, u *url.URL, notify bool) (bool, string, error) {
 			setName := u.Query().Get("set")
 			if setName == "" {
-				return false, errors.New("empty set name")
+				return false, "", errors.New("empty set name")
 			}
 			changed, err := store.StoreEnrollmentSet(ctx, resource, setName)
-			if err == nil && changed {
+			if err == nil && changed && notify {
 				err = notifier.Changed(ctx, nil, nil, []string{resource})
 				if err != nil {
 					err = fmt.Errorf("notify enrollment: %w", err)
 				}
 			}
-			return changed, err
+			return changed, "store enrollment set", err
 		},
 	)
 }
@@ -57,16 +57,19 @@ func PutEnrollmentSetHandler(store EnrollmentAPIStorage, notifier Notifier, logg
 func DeleteEnrollmentSetHandler(store EnrollmentAPIStorage, notifier Notifier, logger log.Logger) http.HandlerFunc {
 	return simpleChangeResourceHandler(
 		logger,
-		func(ctx context.Context, resource string, u *url.URL) (bool, error) {
+		func(ctx context.Context, resource string, u *url.URL, notify bool) (bool, string, error) {
 			setName := u.Query().Get("set")
 			if setName == "" {
-				return false, errors.New("empty set name")
+				return false, "", errors.New("empty set name")
 			}
 			changed, err := store.RemoveEnrollmentSet(ctx, resource, setName)
-			if err == nil && changed {
+			if err == nil && changed && notify {
 				err = notifier.Changed(ctx, nil, nil, []string{resource})
+				if err != nil {
+					err = fmt.Errorf("notify enrollment: %w", err)
+				}
 			}
-			return changed, err
+			return changed, "remove enrollment set", err
 		},
 	)
 }

--- a/http/api/enrollments.go
+++ b/http/api/enrollments.go
@@ -41,7 +41,7 @@ func PutEnrollmentSetHandler(store EnrollmentAPIStorage, notifier Notifier, logg
 			}
 			changed, err := store.StoreEnrollmentSet(ctx, resource, setName)
 			if err == nil && changed {
-				err = notifier.EnrollmentChanged(ctx, resource)
+				err = notifier.Changed(ctx, nil, nil, []string{resource})
 				if err != nil {
 					err = fmt.Errorf("notify enrollment: %w", err)
 				}
@@ -64,7 +64,7 @@ func DeleteEnrollmentSetHandler(store EnrollmentAPIStorage, notifier Notifier, l
 			}
 			changed, err := store.RemoveEnrollmentSet(ctx, resource, setName)
 			if err == nil && changed {
-				err = notifier.EnrollmentChanged(ctx, resource)
+				err = notifier.Changed(ctx, nil, nil, []string{resource})
 			}
 			return changed, err
 		},

--- a/http/api/notify.go
+++ b/http/api/notify.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/jessepeterson/kmfddm/log"
+)
+
+// NotifyHandler notifies enrollment IDs.
+func NotifyHandler(notifier Notifier, logger log.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := notifier.Changed(
+			r.Context(),
+			r.URL.Query()["declaration"],
+			r.URL.Query()["set"],
+			r.URL.Query()["id"],
+		)
+		if err != nil {
+			jsonErrorAndLog(w, http.StatusInternalServerError, err, "notify changed", logger)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/http/api/sets.go
+++ b/http/api/sets.go
@@ -44,7 +44,7 @@ func PutSetDeclarationHandler(store SetAPIStorage, notifier Notifier, logger log
 			}
 			changed, err := store.StoreSetDeclaration(ctx, resource, declarationID)
 			if err == nil && changed {
-				err = notifier.SetChanged(ctx, resource)
+				err = notifier.Changed(ctx, nil, []string{resource}, nil)
 				if err != nil {
 					err = fmt.Errorf("notify set: %w", err)
 				}
@@ -67,7 +67,7 @@ func DeleteSetDeclarationHandler(store SetAPIStorage, notifier Notifier, logger 
 			}
 			changed, err := store.RemoveSetDeclaration(ctx, resource, declarationID)
 			if err == nil && changed {
-				err = notifier.SetChanged(ctx, resource)
+				err = notifier.Changed(ctx, nil, []string{resource}, nil)
 			}
 			return changed, err
 		},

--- a/http/ddm/ddm.go
+++ b/http/ddm/ddm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jessepeterson/kmfddm/ddm"
 	"github.com/jessepeterson/kmfddm/log"
 	"github.com/jessepeterson/kmfddm/log/ctxlog"
+	"github.com/jessepeterson/kmfddm/storage"
 )
 
 const (
@@ -30,10 +31,6 @@ func parseDeclPath(r *http.Request) (string, string, error) {
 	return split[0], split[1], nil
 }
 
-type DeclarationRetriever interface {
-	RetrieveEnrollmentDeclarationJSON(ctx context.Context, declarationID, declarationType, enrollmentID string) ([]byte, error)
-}
-
 func ErrorAndLog(w http.ResponseWriter, status int, logger log.Logger, msg string, err error) {
 	logger.Info("msg", msg, "err", err)
 	http.Error(w, http.StatusText(status), status)
@@ -42,7 +39,7 @@ func ErrorAndLog(w http.ResponseWriter, status int, logger log.Logger, msg strin
 // DeclarationHandler creates a handler that fetches and returns a single declaration.
 // The request URL path is assumed to contain the declaration type and identifier.
 // This probably requires the handler to have the path prefix stripped before use.
-func DeclarationHandler(store DeclarationRetriever, logger log.Logger) http.HandlerFunc {
+func DeclarationHandler(store storage.DeclarationRetriever, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := ctxlog.Logger(r.Context(), logger)
 		declarationType, declarationID, err := parseDeclPath(r)
@@ -74,14 +71,9 @@ func DeclarationHandler(store DeclarationRetriever, logger log.Logger) http.Hand
 	}
 }
 
-type TokensDeclarationItemsRetriever interface {
-	RetrieveDeclarationItemsJSON(ctx context.Context, enrollmentID string) ([]byte, error)
-	RetrieveTokensJSON(ctx context.Context, enrollmentID string) ([]byte, error)
-}
-
 // TokensDeclarationItemsHandler creates a handler that fetchs and returns either
 // the tokens or declaration items JSON for an erollment ID depending on tokens.
-func TokensDeclarationItemsHandler(store TokensDeclarationItemsRetriever, tokens bool, logger log.Logger) http.HandlerFunc {
+func TokensDeclarationItemsHandler(store storage.TokensDeclarationItemsRetriever, tokens bool, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := ctxlog.Logger(r.Context(), logger)
 		var err error

--- a/storage/file/ddm.go
+++ b/storage/file/ddm.go
@@ -35,7 +35,7 @@ func (s *File) RetrieveTokensJSON(_ context.Context, enrollmentID string) ([]byt
 // writeDeclarationDDM looks up the enrollments associated with a declaration and writes the DDM files for each.
 func (s *File) writeDeclarationDDM(declarationID string) error {
 	// first find all enrollment IDs mapped to this declaration.
-	declarationIDs, err := s.declarationEnrollmentIDs(declarationID)
+	declarationIDs, err := s.retrieveEnrollmentIDs([]string{declarationID}, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/storage/mysql/ddm.go
+++ b/storage/mysql/ddm.go
@@ -53,7 +53,7 @@ SELECT DISTINCT
     d.identifier,
     d.type,
     d.server_token
-	FROM
+FROM
     declarations d
     INNER JOIN set_declarations sd
         ON d.identifier = sd.declaration_identifier

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -9,3 +9,28 @@ type Toucher interface {
 	// TouchDeclaration forces a change only to a declaration's ServerToken.
 	TouchDeclaration(ctx context.Context, declarationID string) error
 }
+
+type EnrollmentIDRetriever interface {
+	// RetrieveEnrollmentIDs retrieves MDM enrollment IDs from storage.
+	// In the case of sets and declarations the transitive associations
+	// are traversed to try and collect the IDs. When multiple slices
+	// are given they should be treated like a logical or (i.e. finding
+	// all enrollment IDs for any of the given slices).
+	// Warning: the results may be very large for e.g. sets (or, transitively,
+	// declarations) that are assigned to many enrollment IDs.
+	RetrieveEnrollmentIDs(ctx context.Context, declarations []string, sets []string, ids []string) ([]string, error)
+}
+
+type TokensJSONRetriever interface {
+	RetrieveTokensJSON(ctx context.Context, enrollmentID string) ([]byte, error)
+}
+
+type TokensDeclarationItemsRetriever interface {
+	RetrieveDeclarationItemsJSON(ctx context.Context, enrollmentID string) ([]byte, error)
+	TokensJSONRetriever
+}
+
+type DeclarationRetriever interface {
+	// RetrieveEnrollmentDeclarationJSON fetches the JSON for a declaration for an enrollment ID.
+	RetrieveEnrollmentDeclarationJSON(ctx context.Context, declarationID, declarationType, enrollmentID string) ([]byte, error)
+}

--- a/storage/test/basic.go
+++ b/storage/test/basic.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/jessepeterson/kmfddm/ddm"
 	"github.com/jessepeterson/kmfddm/http/api"
-	httpddm "github.com/jessepeterson/kmfddm/http/ddm"
-	"github.com/jessepeterson/kmfddm/notifier"
 	"github.com/jessepeterson/kmfddm/storage"
 )
 
@@ -22,9 +20,9 @@ const testDecl = `{
 type allTestStorage interface {
 	setAndDeclStorage
 	api.EnrollmentAPIStorage
-	notifier.EnrollmentIDFinder
-	httpddm.TokensDeclarationItemsRetriever
+	storage.TokensDeclarationItemsRetriever
 	storage.Toucher
+	storage.EnrollmentIDRetriever
 }
 
 func TestBasic(t *testing.T, storage allTestStorage, ctx context.Context) {

--- a/tools/syncdir.py
+++ b/tools/syncdir.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+"""
+KMFDDM sync tool. This tool synchronizes declarations and sets from
+a directory and uploads them to a KMFDDM server. It tries to be smart
+about only notifying the changed items (declarations, sets) and only
+performing one set of notifications for all changed items.
+
+The specified directory is walked to find files that can be synced. Any
+file with a ".json" extension is assumed to be declaration and is
+uploaded as such. Files matching "set.$SET.txt" are assumed to contain
+one line for each declaration identifier wanting to be associated to
+"$SET" set name. Include a minus ("-") sign in front of a declaration
+to dissociate it, or an octothorp/hash ("#") for a comment.
+
+For example a directory might look like this:
+
+  ./a/com.example.test.json
+  ./b/com.example.act.json
+  ./c/set.default.txt
+
+Here each of the two JSON files will be treated as declarations and the
+txt file will apply each declaration (one per line) to the "default"
+set.
+"""
+
+import os
+import json
+import urllib.request
+from urllib.parse import urlencode
+import argparse
+import base64
+import re
+
+set_pattern = r"set\.(.*?)\.txt"
+
+nonotify_params = urlencode(
+    {
+        "nonotify": "1",
+    }
+)
+
+
+def make_declaration_req(
+    base_url: str, auth_header: str, declaraion_data: bytes
+) -> urllib.request.Request:
+    url = base_url + "/v1/declarations?" + nonotify_params
+    req = urllib.request.Request(url=url, method="PUT")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Authorization", f"Basic {auth_header}")
+    req.data = declaraion_data
+    return req
+
+
+def make_set_req(
+    base_url: str, auth_header: str, method: str, set_name: str, declaration_id: str
+) -> urllib.request.Request:
+    url = (
+        base_url
+        + "/v1/set-declarations/"
+        + set_name
+        + "?"
+        + urlencode(
+            {
+                "declaration": declaration_id,
+                "nonotify": "1",
+            }
+        )
+    )
+    req = urllib.request.Request(url=url, method=method)
+    req.add_header("Authorization", f"Basic {auth_header}")
+    return req
+
+
+def sync_dir(dir, base_url, key):
+    # collectors for later notifying/reporting
+    changed_decls = []
+    unchanged_decls = []
+    changed_sets = []
+    unchanged_sets = []
+
+    auth_header = base64.b64encode(f"kmfddm:{key}".encode("utf-8")).decode("utf-8")
+    set_files = []
+    for root, dirs, files in os.walk(dir):
+        for file in files:
+            file_path = os.path.join(root, file)
+            if file.endswith(".json"):
+                with open(file_path, "rb") as f:
+                    try:
+                        data = f.read()
+                        decl = json.loads(data)
+                        req = make_declaration_req(base_url, auth_header, data)
+                        response = urllib.request.urlopen(req)
+                        status_code = response.getcode()
+                        if status_code == 204:
+                            id = decl["Identifier"]
+                            print(f"changed declaration {id}")
+                            changed_decls.append(id)
+                        else:
+                            print(
+                                f"WARNING: unknown status code declaration: {status_code}"
+                            )
+                    except json.JSONDecodeError as e:
+                        print(f"ERROR parsing {file}: {str(e)}")
+                    except urllib.error.HTTPError as e:
+                        if e.code == 304:
+                            unchanged_decls.append(decl["Identifier"])
+                        else:
+                            json_error = ""
+                            try:
+                                json_error = json.loads(e.read())["error"]
+                            except:
+                                pass
+                            print(f"ERROR uploading {file}: {str(e)}: {json_error}")
+                    except urllib.error.URLError as e:
+                        print(f"ERROR uploading {file}: {str(e)}")
+            else:
+                match = re.search(set_pattern, file)
+                if not match:
+                    continue
+                # just collect them for now as we want to process
+                # sets after all of the declarations have been uploaded
+                set_files.append((file_path, file, match.group(1)))
+
+    for file_path, file, set_name in set_files:
+        with open(file_path, "r") as f:
+            decls = [line.strip() for line in f]
+            changed_set = False
+            for decl_id in decls:
+                if decl_id == "" or decl_id[0] == "#":
+                    # comment
+                    continue
+                method = "PUT"
+                if decl_id[0] == "-":
+                    # a declaration in a set file preceded with a minus (-)
+                    # indicates removal of the association
+                    decl_id = decl_id[1:].strip()
+                    method = "DELETE"
+                req = make_set_req(base_url, auth_header, method, set_name, decl_id)
+                try:
+                    response = urllib.request.urlopen(req)
+                    status_code = response.getcode()
+                    if status_code == 204:
+                        if method == "PUT":
+                            print(
+                                f"associated declaration {decl_id} with set {set_name}"
+                            )
+                        elif method == "DELETE":
+                            print(
+                                f"dissociated declaration {decl_id} from set {set_name}"
+                            )
+                        changed_set = True
+                    else:
+                        print(f"WARNING: unknown status code sets: {status_code}")
+                except urllib.error.HTTPError as e:
+                    if e.code != 304:
+                        json_error = ""
+                        try:
+                            json_error = json.loads(e.read())["error"]
+                        except:
+                            pass
+                        print(
+                            f"ERROR associating {decl_id} with {set_name}: {str(e)}: {json_error}"
+                        )
+                except urllib.error.URLError as e:
+                    print(f"ERROR associating {decl_id} with {set_name}: {str(e)}")
+            if changed_set:
+                changed_sets.append(set_name)
+            else:
+                unchanged_sets.append(set_name)
+
+    if len(unchanged_decls) > 0:
+        print(f"unchanged declarations: {len(unchanged_decls)}")
+    if len(unchanged_sets) > 0:
+        print(f"unchanged sets: {len(unchanged_sets)}")
+
+    if len(changed_decls) > 0 or len(changed_sets) > 0:
+        params = {}
+        if len(changed_decls) > 0:
+            params["declaration"] = changed_decls
+            print(
+                f"changed declarations ({len(changed_decls)}): "
+                + ", ".join(changed_decls)
+            )
+        if len(changed_sets) > 0:
+            params["set"] = changed_sets
+            print(f"changed sets ({len(changed_sets)}): " + ", ".join(changed_sets))
+        encoded_params = urlencode(params, doseq=True)
+        notify_url = base_url + "/v1/notify?" + encoded_params
+        req = urllib.request.Request(url=notify_url, method="POST")
+        req.add_header("Authorization", f"Basic {auth_header}")
+        try:
+            response = urllib.request.urlopen(req)
+            status_code = response.getcode()
+            if status_code == 204:
+                print(f"sent notify")
+            else:
+                print(f"WARNING: unknown status code notify: {status_code}")
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            print(f"ERROR notifying to {notify_url}: {str(e)}")
+    else:
+        print("no changed declarations or sets")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="KMFDDM syncer",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.epilog = __doc__
+    parser.add_argument(
+        "dir",
+        type=str,
+        help="path to the directory containing declarations and set files",
+    )
+    parser.add_argument(
+        "--baseurl",
+        type=str,
+        default="http://[::1]:9002",
+        help="URL for uploading the JSON files (default: http://[::1]:9002)",
+    )
+    parser.add_argument(
+        "--key",
+        type=str,
+        default="kmfddm",
+        help="Password for HTTP Basic authentication",
+    )
+    args = parser.parse_args()
+
+    sync_dir(args.dir, args.baseurl, args.key)


### PR DESCRIPTION
Previously any change to a set, enrollment, or declaration would trigger a notification (which, in turn, sends out the MDMv1 `DeclarativeManagement` command). This PR introduces the capability to set a `nonotify=1` URL param which defers notification for your actual changes. We also introduce a `/v1/notify?...` endpoint which allows specifying all changed items. To enable this the storage backends now "roll-up" all the enrollment IDs (to optimize the case of many overlapping set<->id<->declarations). It is hoped, in the end, that this reduces unnecessary notifications (MDMv1 command sends) and reduces load for both KMFDDM and e.g. NanoMDM.

With the above added support we introduce a new tool: `./tools/syncdir.py`. From its docstring:

> KMFDDM sync tool. This tool synchronizes declarations and sets from a directory and uploads them to a KMFDDM server. It tries to be smart about only notifying the changed items (declarations, sets) and only performing one set of notifications for all changed items.
