### PR TITLE
add jsonpath and refactor status parsing to use it

### DIFF
--- a/ddm/status_test.go
+++ b/ddm/status_test.go
@@ -14,7 +14,7 @@ func TestStatusParse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s, err := ParseStatus(jsonBytes)
+	_, s, err := ParseStatus(jsonBytes)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http/ddm/ddm.go
+++ b/http/ddm/ddm.go
@@ -135,7 +135,7 @@ func StatusReportHandler(store storage.StatusStorer, hLogger log.Logger) http.Ha
 			ErrorAndLog(w, http.StatusInternalServerError, logger, "reading body", err)
 			return
 		}
-		status, err := ddm.ParseStatus(bodyBytes)
+		unhandled, status, err := ddm.ParseStatus(bodyBytes)
 		if err != nil {
 			ErrorAndLog(w, http.StatusInternalServerError, logger, "parsing status report", err)
 			return
@@ -145,6 +145,9 @@ func StatusReportHandler(store storage.StatusStorer, hLogger log.Logger) http.Ha
 			logkeys.ErrorCount, len(status.Errors),
 			logkeys.ValueCount, len(status.Values),
 		)
+		for _, u := range unhandled {
+			logger.Debug(logkeys.Message, "unhandled status path", "path", u)
+		}
 		err = store.StoreDeclarationStatus(ctx, enrollmentID, status)
 		if err != nil {
 			ErrorAndLog(w, http.StatusInternalServerError, logger, "storing declaration status", err)

--- a/jsonpath/jsonpath.go
+++ b/jsonpath/jsonpath.go
@@ -1,0 +1,222 @@
+// Package jsonpath is a JSON object "path-based" parser based on fastjson.
+package jsonpath
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/valyala/fastjson"
+)
+
+// Handlers process parts of JSON structures at paths.
+//
+// Paths are dot/period-separated locations in the JSON structure.
+// Optionally a Handler can return the slice of "unhandled" paths it may
+// have traversed.
+// Be judicious with returning errors. They may stop processing of the
+// JSON structure before other parts have been reached or other handlers
+// run instead returning an error for the entire process.
+type Handler interface {
+	JSONPath(path string, v *fastjson.Value) ([]string, error)
+}
+
+// HandlerFunc is an adapter that allows using functions as Handlers.
+type HandlerFunc func(path string, v *fastjson.Value) ([]string, error)
+
+// JSONPath calls f(path, v).
+func (f HandlerFunc) JSONPath(path string, v *fastjson.Value) ([]string, error) {
+	return f(path, v)
+}
+
+// pathHandlerMap maps dot/period-separated path elements to pathHandlers.
+type pathHandlerMap map[string]*pathHandlers
+
+// pathHandlers is container for handlers for paths.
+type pathHandlers struct {
+	handlers     []Handler
+	wcHandlers   []Handler
+	pathHandlers pathHandlerMap
+}
+
+// PathMux traverses JSON objects to handle dot/period-separated paths.
+//
+// Paths are dot/period-separated locations in the JSON structure.
+// TThere are two varieties of handler paths: normal handlers and
+// "wildcard" handlers. Normal handlers exactly match the path in the
+// JSON and are handled when found. Wildcard handlers, which end in a
+// dot/period, are called for every non-JSON object key recursively.
+//
+// For example the handler path ".foo.bar.baz" is a normal handler and
+// would be called if the source JSON looked something like
+// `{"foo": {"bar": {"baz": true, "qux": false}}}`. However the handler
+// path ".foo.bar." is a wildcard (as denoted by the trailing period)
+// and the handler will get called for each of the paths ".foo.bar.baz",
+// and ".foo.bar.qux".
+//
+// Normal and wildcard handlers can be registered "lower" (deeper in the
+// JSON structure) than higher-level wildcard handlers. Normal handlers
+// will stop traversing the structure to handle any registered handlers.
+// Only the "lowest" wildcard handler will be dispatched to if more than
+// one match for a path. Multiple handlers (of either type) can be
+// registered for a path.
+type PathMux struct {
+	mu           sync.RWMutex
+	pathHandlers pathHandlerMap
+}
+
+// NewPathMux returns a new PathMux.
+func NewPathMux() *PathMux {
+	return new(PathMux)
+}
+
+// Handle registers h for path in the JSON structure.
+// Multiple handlers can be registered for a path.
+// Panic ensues if h is nil.
+func (m *PathMux) Handle(path string, h Handler) {
+	if h == nil {
+		panic("jsonpath: nil handler")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pathElems := strings.Split(path, ".")
+
+	// the end of the pathElems
+	end := len(pathElems) - 1
+	// the end of the pathElems for "wildcard" Handlers
+	wcEnd := end - 1
+
+	// point at the "root" pathHandler of the muxer
+	curPathHandlers := &m.pathHandlers
+
+	for i, pathElem := range pathElems {
+		if *curPathHandlers == nil {
+			*curPathHandlers = make(pathHandlerMap)
+		}
+		handlers, ok := (*curPathHandlers)[pathElem]
+		if !ok || handlers == nil {
+			handlers = &pathHandlers{}
+			(*curPathHandlers)[pathElem] = handlers
+		}
+		if i == wcEnd && pathElems[end] == "" {
+			// setup a "wildcard" Handler
+			handlers.wcHandlers = append(handlers.wcHandlers, h)
+			break
+		} else if i == end {
+			// setup a Handler
+			handlers.handlers = append(handlers.handlers, h)
+		}
+
+		// re-point at the next pathHandler
+		curPathHandlers = &handlers.pathHandlers
+	}
+}
+
+// HandleFunc registers f for path in the JSON structure.
+func (m *PathMux) HandleFunc(path string, f HandlerFunc) {
+	m.Handle(path, f)
+}
+
+// processValue recursively traverses JSON structure v.
+func (m *PathMux) processValue(handlerMap pathHandlerMap, pathElems []string, curElem int, v *fastjson.Value, wcHandlers []Handler) ([]string, error) {
+	curPath := pathElems[curElem]
+	path := strings.Join(pathElems, ".")
+	handlers, ok := handlerMap[curPath]
+	if ok && handlers != nil && len(handlers.wcHandlers) > 0 {
+		// everything from this position and deeper will have wcHandlers
+		// (we pass wcHandlers to the recursive call). this faciliates
+		// wildcard handlers.
+		wcHandlers = handlers.wcHandlers
+	}
+	var unhandled, tmpUnhandled []string
+	var err error
+	if (!ok || handlers == nil) && len(wcHandlers) < 1 {
+		// end of the line. if we're not in the pathHandlerMap and
+		// there are no wildcard handlers at this position then
+		// nothing will be found for this path. report it back up the
+		// recursive call.
+		return []string{path}, nil
+	} else if handlers != nil && len(handlers.handlers) > 0 {
+		// if we have specific handlers for this path then run them
+		// (and only them).
+		for i, h := range handlers.handlers {
+			tmpUnhandled, err = h.JSONPath(path, v)
+			unhandled = append(unhandled, tmpUnhandled...)
+			if err != nil {
+				return unhandled, fmt.Errorf("Handler %d at path %s: %w", i, path, err)
+			}
+		}
+		return unhandled, nil
+	}
+	switch v.Type() {
+	case fastjson.TypeObject:
+		o, err := v.Object()
+		if err != nil {
+			return unhandled, fmt.Errorf("getting object at path %s: %w", path, err)
+		}
+		if handlers == nil {
+			handlers = &pathHandlers{}
+		}
+		o.Visit(func(k []byte, v *fastjson.Value) {
+			if err != nil {
+				// don't go further if we have any errors
+				return
+			}
+			tmpUnhandled, err = m.processValue(handlers.pathHandlers, append(pathElems, string(k)), curElem+1, v, wcHandlers)
+			// accumulate our unhandled paths
+			unhandled = append(unhandled, tmpUnhandled...)
+		})
+		if err != nil {
+			return unhandled, fmt.Errorf("visiting object path %s: %w", path, err)
+		}
+	default:
+		if len(wcHandlers) > 0 {
+			// dispatch to wildcard handlers
+			for i, h := range wcHandlers {
+				tmpUnhandled, err = h.JSONPath(path, v)
+				unhandled = append(unhandled, tmpUnhandled...)
+				if err != nil {
+					return unhandled, fmt.Errorf("wildcard Handler %d at path %s: %w", i, path, err)
+				}
+			}
+			return unhandled, nil
+		}
+	}
+	return unhandled, nil
+}
+
+// JSONPath parses v dispatching to any registered handlers for paths.
+func (m *PathMux) JSONPath(path string, v *fastjson.Value) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.processValue(m.pathHandlers, strings.Split(path, "."), 0, v, nil)
+}
+
+// StripAndAddPrefix is a middleware that removes pathPrefix from
+// handler calls and adds it back when returning unhandled paths.
+func StripAndAddPrefix(pathPrefix string, next Handler) Handler {
+	if pathPrefix == "" {
+		return next
+	}
+	return HandlerFunc(func(path string, v *fastjson.Value) ([]string, error) {
+		p := strings.TrimPrefix(path, pathPrefix)
+		unhandled, err := next.JSONPath(p, v)
+		unhandledPrefix := make([]string, len(unhandled))
+		for i, v := range unhandled {
+			unhandledPrefix[i] = pathPrefix + v
+		}
+		return unhandledPrefix, err
+	})
+}
+
+// AddPrefix is a middleware that prefixes pathPrefix to handler calls.
+func AddPrefix(pathPrefix string, next Handler) Handler {
+	if pathPrefix == "" {
+		return next
+	}
+	return HandlerFunc(func(path string, v *fastjson.Value) ([]string, error) {
+		return next.JSONPath(pathPrefix+path, v)
+	})
+}

--- a/jsonpath/jsonpath_test.go
+++ b/jsonpath/jsonpath_test.go
@@ -1,0 +1,135 @@
+package jsonpath
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/valyala/fastjson"
+)
+
+const test1 = `{"foo": {"bar": {"baz": true, "qux": false}}}`
+
+func TestUnhandled(t *testing.T) {
+	v, err := fastjson.ParseBytes([]byte(test1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := NewPathMux()
+	mux.HandleFunc(".foo.bar.baz", func(string, *fastjson.Value) ([]string, error) { return nil, nil })
+	unhandled, err := mux.JSONPath("", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have, want := unhandled, []string{".foo.bar.qux"}; !reflect.DeepEqual(have, want) {
+		t.Errorf("have: %q, want %q", have, want)
+	}
+}
+
+// valCaptureHandler just collects the objects it has handled
+type valCaptureHandler struct {
+	vals []struct {
+		path string
+		v    *fastjson.Value
+	}
+}
+
+func (h *valCaptureHandler) JSONPath(path string, v *fastjson.Value) ([]string, error) {
+	h.vals = append(h.vals, struct {
+		path string
+		v    *fastjson.Value
+	}{path: path, v: v})
+	return nil, nil
+}
+
+// collapse reduces the collected objects to a map and returns it.
+// potentially overwriting multiple handlers at the same path.
+func (h *valCaptureHandler) collapse() map[string]*fastjson.Value {
+	ret := make(map[string]*fastjson.Value)
+	for _, v := range h.vals {
+		ret[v.path] = v.v
+	}
+	return ret
+}
+
+func TestBasicWildcard(t *testing.T) {
+	v, err := fastjson.ParseBytes([]byte(test1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := NewPathMux()
+	cap := new(valCaptureHandler)
+	mux.Handle(".foo.bar.", cap)
+	_, err = mux.JSONPath("", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	col := cap.collapse()
+	if have, want := col[".foo.bar.baz"].Type(), fastjson.TypeTrue; have != want {
+		t.Errorf("have: %q, want %q", have, want)
+	}
+	if have, want := col[".foo.bar.qux"].Type(), fastjson.TypeFalse; have != want {
+		t.Errorf("have: %q, want %q", have, want)
+	}
+}
+
+func TestWildcardWithNormal(t *testing.T) {
+	v, err := fastjson.ParseBytes([]byte(test1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := NewPathMux()
+	cap := new(valCaptureHandler)
+	cap2 := new(valCaptureHandler)
+	mux.Handle(".foo.bar.", cap)
+	mux.Handle(".foo.bar.baz", cap2)
+	_, err = mux.JSONPath("", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have, want := cap2.collapse()[".foo.bar.baz"].Type(), fastjson.TypeTrue; have != want {
+		t.Errorf("have: %q, want %q", have, want)
+	}
+	if have, want := cap.collapse()[".foo.bar.qux"].Type(), fastjson.TypeFalse; have != want {
+		t.Errorf("have: %q, want %q", have, want)
+	}
+}
+
+// TestEmbedded tests two PathMuxes embedded one-inside-the-other.
+func TestEmbedded(t *testing.T) {
+	v, err := fastjson.ParseBytes([]byte(test1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	muxOuter := NewPathMux()
+	muxInner := NewPathMux()
+	cap := new(valCaptureHandler)
+	muxOuter.Handle(".foo", StripAndAddPrefix(".foo", muxInner))
+	muxInner.Handle(".bar.", AddPrefix(".foo", cap))
+	unhandled, err := muxOuter.JSONPath("", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unhandled) > 0 {
+		t.Errorf("unhandled should be empty: %q", unhandled)
+	}
+	col := cap.collapse()
+	if have, want := col[".foo.bar.baz"].Type(), fastjson.TypeTrue; have != want {
+		t.Errorf("have: %q, want %q", have, want)
+	}
+	if have, want := col[".foo.bar.qux"].Type(), fastjson.TypeFalse; have != want {
+		t.Errorf("have: %q, want %q", have, want)
+	}
+}
+
+func TestHandle(t *testing.T) {
+	m := NewPathMux()
+
+	m.HandleFunc(".foo.bar.baz", func(string, *fastjson.Value) ([]string, error) { return nil, nil })
+
+	// verify we've properly setup our pathHandlers and have the handler attached
+	pH := m.pathHandlers[""].pathHandlers["foo"].pathHandlers["bar"].pathHandlers["baz"]
+
+	if have, want := len(pH.handlers), 1; have != want {
+		t.Errorf("have: %v, want: %v", have, want)
+	}
+}


### PR DESCRIPTION
We want a way to more flexibly parse our status JSON and hand-off responsibility for portions of the JSON we don't/won't need to support. This is in contrast to supporting the _entire_ declarative management status updates — we'd like a way to delegate just the responsible parties access to the status that they need.

To that end we introduce `jsonpath`: a Go package for parsing JSON structures and "handling" dot/period-separated paths. If you're familiar with `http.ServeMux` you'll see the similarities. For example in this JSON:

```json
{
	"foo": {
		"bar": {
			"baz": true,
			"qux": false
		}
	}
}
```

We can "handle" a path by just specifying ".foo.bar.baz" and your handler will be called once it reaches that place in the JSON structure. For example if you setup your handlers like this:

```go
mux := jsonpath.NewPathMux()
mux.Handle(".foo.bar.baz", myHandler)
unhandled, err := mux.JSONPath("", v)
```

`myHandler` would be called back with a fastjson reference and a path string to handle that part of the JSON. You can even nest `PathMux`ers (though you need to take care about how paths are handled and if you want to handle them in a relative fashion).

In this PR we introduce this the `jsonpath` package and we refactor the status report parsing in the `ddm` package to use it. We also log the "unhandled" portions of the JSON to make sure we catch these if we meant to log them. For example:

```
ts=2023-08-01T13:05:00-07:00 [snip] msg=unhandled status path path=.StatusItems.diskmanagement caller=ddm.go:149
ts=2023-08-01T13:05:00-07:00 [snip] msg=unhandled status path path=.StatusItems.softwareupdate caller=ddm.go:149
ts=2023-08-01T13:05:00-07:00 [snip] msg=unhandled status path path=.StatusItems.services caller=ddm.go:149
```