### PR TITLE
Status Report updates

### DIFF
--- a/cmd/kmfddm/main.go
+++ b/cmd/kmfddm/main.go
@@ -35,6 +35,7 @@ func main() {
 		flVersion = flag.Bool("version", false, "print version")
 		flStorage = flag.String("storage", "file", "storage backend")
 		flDSN     = flag.String("storage-dsn", "", "storage data source name")
+		flOptions = flag.String("storage-options", "", "storage backend options")
 
 		flDumpStatus = flag.String("dump-status", "", "file name to dump status reports to (\"-\" for stdout)")
 
@@ -56,7 +57,7 @@ func main() {
 		logger.Info(logkeys.Message, "empty API key; API disabled")
 	}
 
-	storage, err := setupStorage(*flStorage, *flDSN)
+	storage, err := setupStorage(*flStorage, *flDSN, *flOptions, logger)
 	if err != nil {
 		logger.Info(logkeys.Message, "init storage", "name", *flStorage, logkeys.Error, err)
 		os.Exit(1)

--- a/cmd/kmfddm/main.go
+++ b/cmd/kmfddm/main.go
@@ -235,6 +235,12 @@ func main() {
 				"GET",
 			)
 
+			mux.Handle(
+				"/v1/status-report/:id",
+				apihttp.GetStatusReportHandler(storage, logger.With(logkeys.Handler, "get-status-report")),
+				"GET",
+			)
+
 			// notifier
 			mux.Handle(
 				"/v1/notify",

--- a/cmd/kmfddm/storage.go
+++ b/cmd/kmfddm/storage.go
@@ -3,8 +3,12 @@ package main
 import (
 	"fmt"
 	"hash"
+	"strconv"
+	"strings"
 
 	"github.com/cespare/xxhash"
+	"github.com/jessepeterson/kmfddm/log"
+	"github.com/jessepeterson/kmfddm/log/logkeys"
 	"github.com/jessepeterson/kmfddm/storage"
 	"github.com/jessepeterson/kmfddm/storage/file"
 	"github.com/jessepeterson/kmfddm/storage/mysql"
@@ -25,13 +29,15 @@ type allStorage interface {
 
 var hasher func() hash.Hash = func() hash.Hash { return xxhash.New() }
 
-func setupStorage(name, dsn string) (allStorage, error) {
+func setupStorage(name, dsn, options string, logger log.Logger) (allStorage, error) {
+	logger = logger.With("storage", name)
+	var mapOptions map[string]string
+	if options != "" {
+		mapOptions = splitOptions(options)
+	}
 	switch name {
 	case "mysql":
-		return mysql.New(
-			hasher,
-			mysql.WithDSN(dsn),
-		)
+		return setupMySQLStorage(dsn, mapOptions, logger)
 	case "file":
 		if dsn == "" {
 			dsn = "db"
@@ -40,4 +46,36 @@ func setupStorage(name, dsn string) (allStorage, error) {
 	default:
 		return nil, fmt.Errorf("unknown storage name: %s", name)
 	}
+}
+
+func setupMySQLStorage(dsn string, options map[string]string, logger log.Logger) (allStorage, error) {
+	opts := []mysql.Option{mysql.WithDSN(dsn)}
+	for k, v := range options {
+		switch k {
+		case "delete_errors":
+			const errorDeleteOption = "error delete option"
+			n, err := strconv.ParseUint(v, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for %s: %w", errorDeleteOption, err)
+			}
+			opts = append(opts, mysql.WithErrorDeletion(uint(n)))
+			logger.Debug(logkeys.Message, errorDeleteOption, logkeys.GenericCount, int(n))
+		default:
+			return nil, fmt.Errorf("invalid option: %q", k)
+		}
+	}
+	return mysql.New(hasher, opts...)
+}
+
+func splitOptions(s string) map[string]string {
+	out := make(map[string]string)
+	opts := strings.Split(s, ",")
+	for _, opt := range opts {
+		optKAndV := strings.SplitN(opt, "=", 2)
+		if len(optKAndV) < 2 {
+			optKAndV = append(optKAndV, "")
+		}
+		out[optKAndV[0]] = optKAndV[1]
+	}
+	return out
 }

--- a/cmd/kmfddm/storage.go
+++ b/cmd/kmfddm/storage.go
@@ -60,6 +60,14 @@ func setupMySQLStorage(dsn string, options map[string]string, logger log.Logger)
 			}
 			opts = append(opts, mysql.WithErrorDeletion(uint(n)))
 			logger.Debug(logkeys.Message, errorDeleteOption, logkeys.GenericCount, int(n))
+		case "delete_status_reports":
+			const reportDeleteOption = "status report delete option"
+			n, err := strconv.ParseUint(v, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for %s: %w", reportDeleteOption, err)
+			}
+			opts = append(opts, mysql.WithStatusReportDeletion(uint(n)))
+			logger.Debug(logkeys.Message, reportDeleteOption, logkeys.GenericCount, int(n))
 		default:
 			return nil, fmt.Errorf("invalid option: %q", k)
 		}

--- a/ddm/status.go
+++ b/ddm/status.go
@@ -33,6 +33,7 @@ type DeclarationQueryStatus struct {
 	DeclarationStatus
 	Current        bool        `json:"current"`
 	StatusReceived time.Time   `json:"status_received"`
+	StatusID       string      `json:"status_id,omitempty"`
 	Reasons        interface{} `json:"reasons,omitempty"`
 }
 
@@ -53,6 +54,8 @@ type StatusError struct {
 
 // StatusReport is the combined parsed and raw status report.
 type StatusReport struct {
+	ID string
+
 	Declarations []DeclarationStatus
 
 	Errors []StatusError
@@ -60,6 +63,7 @@ type StatusReport struct {
 	// the "raw" status report values not otherwise parsed
 	Values []StatusValue
 
+	// the raw JSON bytes of the status report
 	Raw []byte
 }
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -355,6 +355,51 @@ paths:
            $ref: '#/components/responses/JSONError'
     parameters:
       - $ref: '#/components/parameters/enrollmentIDs'
+  /v1/status-report/{id}:
+    get:
+      description: Retrieve a saved raw status report for an enrollment.
+      tags:
+        - status
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: The status report JSON.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StatusItems:
+                    type: object
+                  Errors:
+                    type: array
+                    items:
+                      type: object
+        '404':
+          $ref: '#/components/responses/JSONNotFound'
+        '401':
+           $ref: '#/components/responses/UnauthorizedError'
+        '400':
+           $ref: '#/components/responses/JSONBadRequest'
+        '500':
+           $ref: '#/components/responses/JSONError'
+    parameters:
+      - $ref: '#/components/parameters/enrollmentID'
+      - in: query
+        name: index
+        description: The status report at this index. Zero (0) means the newest status report. One is the report received before that, and so on.
+        schema:
+          type: integer
+        example: 0
+        required: false
+      - in: query
+        name: status_id
+        description: The status ID of the status report.
+        schema:
+          type: string
+        example: 'deb0cb542b4e1566'
+        required: false
   /v1/status-values/{id}:
     get:
       description: Retrieve status values saved from status reports.
@@ -584,6 +629,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/JSONError'  
+    JSONNotFound:
+      description: The resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/JSONError'
     JSONError:
       description: An internal server error occured on this endpoint.
       content:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -300,6 +300,10 @@ paths:
                           description: Timestamp of when this declaration's status was last received.
                         reasons:
                           type: object
+                        status_id:
+                          type: string
+                          description: The status ID of the Status Report this value was last seen on.
+                          example: '0cd0246e536abe1a'
         '401':
            $ref: '#/components/responses/UnauthorizedError'
         '400':
@@ -337,7 +341,12 @@ paths:
                           description: Error object from status report.
                         timestamp:
                           type: string
-                          description: Timestamp of when the the status report that repoted this error was received.
+                          description: The timestamp of the Status Report this error was last seen at.
+                          example: '2023-08-04T06:26:02Z'
+                        status_id:
+                          type: string
+                          description: The status ID of the Status Report this error was last seen on.
+                          example: '0cd0246e536abe1a'
         '401':
            $ref: '#/components/responses/UnauthorizedError'
         '400':
@@ -355,7 +364,7 @@ paths:
         - basicAuth: []
       responses:
         '200':
-          description: Status errors.
+          description: Status values. Values under the `.StatusItems.management.` tree reported to the client (that are not declaration status).
           content:
             application/json:
               schema:
@@ -373,6 +382,14 @@ paths:
                         value:
                           type: string
                           example: 'ZMX24NJ671'
+                        timestamp:
+                          type: string
+                          description: The timestamp of the Status Report this value was last seen at.
+                          example: '2023-08-04T06:26:02Z'
+                        status_id:
+                          type: string
+                          description: The status ID of the Status Report this value was last seen on.
+                          example: '0cd0246e536abe1a'
         '401':
            $ref: '#/components/responses/UnauthorizedError'
         '400':

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -364,7 +364,21 @@ paths:
         - basicAuth: []
       responses:
         '200':
-          description: The status report JSON.
+          description: Status Report JSON.
+          headers:
+            Last-Modified:
+              description: When the status report was received by the client.
+              schema:
+                type: string
+            X-Status-Report-ID:
+              description: Status Report identifier. Typically this is the trace ID of the original HTTP request that this status report was seen from.
+              schema:
+                type: string
+            X-Status-Report-Index:
+              description: The status report "index". A reverse-chronological identifier, per enrollment ID, for this status report. I.e. index zero (`0`) is the last status report seen from a client.
+              schema:
+                type: integer
+                example: 0
           content:
             application/json:
               schema:

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -1,0 +1,90 @@
+# KMFDDM Operations Guide
+
+This is a brief technical overview of the KMFDDM server and related tools.
+
+Refer to the [project README](../README.md) for a conceptual introduction to KMFDDM and the [Quickstart Guide](quickstart.md) can be used for getting a basic environment up and running. This document is intended for more operational details.
+
+## kmfddm
+
+### Switches
+
+#### -version
+
+* print version
+
+Print version and exit.
+
+#### -api string
+
+ * API key for API endpoints
+
+Required. API authentication in NanoDEP is simply HTTP Basic authentication using "kmfddm" as the username and the API key (from this switch) as the password.
+
+#### -cors-origin string
+
+ * CORS Origin; for browser-based API access
+
+Sets CORS origin and related HTTP headers on requests.
+
+#### -debug
+
+ * log debug messages
+
+Enable additional debug logging.
+
+#### -dump-status string
+
+ * file name to dump status reports to ("-" for stdout)
+
+KMFDDM supports dumping the JSON Declarative Device Management status report to a file. Specify a dash (`-`) to dump to stdout.
+
+#### -enqueue string
+
+ * URL of MDM server enqueue endpoint
+
+URL of the MDM server for enqueuing commands. The enrollmnet ID is added onto this URL as a path element (or multiple, if the MDM server supports it).
+
+#### -enqueue-key string
+
+ * MDM server enqueue API key
+
+The API key (HTTP Basic authentication password) for the MDM server enqueue endpoint. The HTTP Basic username depends on the MDM mode. By default it is "nanomdm" but if the `-micromdm` (see below) flag is enabled then it is "micromdm".
+
+#### -listen string
+
+ * HTTP listen address (default ":9002")
+
+Specifies the listen address (interface and port number) for the server to listen on.
+
+#### -micromdm
+
+ * Use MicroMDM command API calling conventions
+
+Submit commands for enqueueing in a style that is compatible with MicroMDM (instead of NanoMDM). Specifically this flag limits sending commands to one enrollment ID at a time, uses a POST request, and changes the HTTP Basic username.
+
+### -storage, -storage-dsn, & -storage-options
+
+The `-storage`, `-storage-dsn`, & `-storage-options` flags together configure the storage backend. `-storage` specifies the name of the backend while `-storage-dsn` specifies the backend data source name (e.g. the connection string). The optional `-storage-options` flag specifies options for the backend (if it supports them). If no storage flags are supplied then it is as if you specified `-storage file -storage-dsn db` meaning we use the `file` storage backend with `db` as its DSN.
+
+#### file storage backend
+
+* `-storage file`
+
+Configures the `file` storage backend. This manages storage data within plain filesystem files and directories. It has zero dependencies and should run out of the box. The `-storage-dsn` flag specifies the filesystem directory for the database. The `file` backend has no storage options.
+
+*Example:* `-storage file -storage-dsn /path/to/my/db`
+
+#### mysql storage backend
+
+* `-storage mysql`
+
+Configures the MySQL storage backend. The `-storage-dsn` flag should be in the [format the SQL driver expects](https://github.com/go-sql-driver/mysql#dsn-data-source-name). Be sure to create your tables with the [schema.sql](../storage/mysql/schema.sql) file that corresponds to your KMFDDM version. Also make sure you apply any schema changes for each updated version (i.e. execute the numbered schema change files). MySQL 8.0.19 or later is required.
+
+*Example:* `-storage mysql -storage-dsn kmfddm:kmfddm/mymdmdb`
+
+Options are specified as a comma-separated list of "key=value" pairs. The mysql backend supports these options:
+
+* `delete_errors=N`
+  * This option sets the maximum number of errors to keep in the database per enrollment ID. A default of zero means to store unlimited errors in the database for each enrollment.
+
+*Example:* `-storage mysql -storage-dsn kmfddm:kmfddm/mymdmdb -storage-options delete_errors=100`

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -86,5 +86,7 @@ Options are specified as a comma-separated list of "key=value" pairs. The mysql 
 
 * `delete_errors=N`
   * This option sets the maximum number of errors to keep in the database per enrollment ID. A default of zero means to store unlimited errors in the database for each enrollment.
+* `delete_status_reports=N`
+  * This option sets the maximum number of errors to keep in the database per enrollment ID. A default of zero means to store unlimited errors in the database for each enrollment.
 
-*Example:* `-storage mysql -storage-dsn kmfddm:kmfddm/mymdmdb -storage-options delete_errors=100`
+*Example:* `-storage mysql -storage-dsn kmfddm:kmfddm/mymdmdb -storage-options delete_errors=20,delete_status_reports=5`

--- a/http/ddm/ddm.go
+++ b/http/ddm/ddm.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/jessepeterson/kmfddm/ddm"
+	httpddm "github.com/jessepeterson/kmfddm/http"
 	"github.com/jessepeterson/kmfddm/log"
 	"github.com/jessepeterson/kmfddm/log/ctxlog"
 	"github.com/jessepeterson/kmfddm/log/logkeys"
@@ -143,10 +144,12 @@ func StatusReportHandler(store storage.StatusStorer, hLogger log.Logger) http.Ha
 			ErrorAndLog(w, http.StatusInternalServerError, logger, "parsing status report", err)
 			return
 		}
+		status.ID = httpddm.GetTraceID(ctx)
 		logger = logger.With(
 			logkeys.DeclarationCount, len(status.Declarations),
 			logkeys.ErrorCount, len(status.Errors),
 			logkeys.ValueCount, len(status.Values),
+			"status_id", status.ID,
 		)
 		for _, u := range unhandled {
 			logger.Debug(logkeys.Message, "unhandled status path", "path", u)

--- a/http/http.go
+++ b/http/http.go
@@ -51,6 +51,11 @@ func VersionHandler(version string) http.HandlerFunc {
 
 type ctxKeyTraceID struct{}
 
+func GetTraceID(ctx context.Context) string {
+	s, _ := ctx.Value(ctxKeyTraceID{}).(string)
+	return s
+}
+
 // TraceLoggingMiddleware sets up a trace ID in the request context and
 // logs HTTP requests.
 func TraceLoggingMiddleware(next http.Handler, logger log.Logger, traceID func(*http.Request) string) http.HandlerFunc {

--- a/storage/file/status.go
+++ b/storage/file/status.go
@@ -467,3 +467,7 @@ func (s *File) RetrieveStatusValues(_ context.Context, enrollmentIDs []string, p
 	}
 	return ret, nil
 }
+
+func (s *File) RetrieveStatusReport(ctx context.Context, q storage.StatusReportQuery) (*storage.StoredStatusReport, error) {
+	return nil, errors.New("[File::RetrieveStatusReport] not implemented")
+}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -13,12 +13,14 @@ const mysqlTimeFormat = "2006-01-02 15:04:05"
 type MySQLStorage struct {
 	db      *sql.DB
 	newHash func() hash.Hash
+	errDel  uint
 }
 
 type config struct {
 	driver string
 	dsn    string
 	db     *sql.DB
+	errDel uint
 }
 
 type Option func(*config)
@@ -45,6 +47,14 @@ func WithDB(db *sql.DB) Option {
 	}
 }
 
+// WithErrorDeletion sets the maximum number of error event rows to keep
+// per enrollment ID.
+func WithErrorDeletion(count uint) Option {
+	return func(c *config) {
+		c.errDel = count
+	}
+}
+
 // New creates and initializes a new MySQL storage backend.
 // New attempts to Ping the database after opening to verify connectivity.
 func New(newHash func() hash.Hash, opts ...Option) (*MySQLStorage, error) {
@@ -65,7 +75,7 @@ func New(newHash func() hash.Hash, opts ...Option) (*MySQLStorage, error) {
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}
-	return &MySQLStorage{db: cfg.db, newHash: newHash}, nil
+	return &MySQLStorage{db: cfg.db, newHash: newHash, errDel: cfg.errDel}, nil
 }
 
 // resultChangedRows tries to tell us if if the record changed. Note that

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -14,6 +14,7 @@ type MySQLStorage struct {
 	db      *sql.DB
 	newHash func() hash.Hash
 	errDel  uint
+	stsDel  uint
 }
 
 type config struct {
@@ -21,6 +22,7 @@ type config struct {
 	dsn    string
 	db     *sql.DB
 	errDel uint
+	stsDel uint
 }
 
 type Option func(*config)
@@ -55,6 +57,14 @@ func WithErrorDeletion(count uint) Option {
 	}
 }
 
+// WithStatusReportDeletion sets the maximum number of status reports
+// rows to keep per enrollment ID.
+func WithStatusReportDeletion(count uint) Option {
+	return func(c *config) {
+		c.stsDel = count
+	}
+}
+
 // New creates and initializes a new MySQL storage backend.
 // New attempts to Ping the database after opening to verify connectivity.
 func New(newHash func() hash.Hash, opts ...Option) (*MySQLStorage, error) {
@@ -75,7 +85,12 @@ func New(newHash func() hash.Hash, opts ...Option) (*MySQLStorage, error) {
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}
-	return &MySQLStorage{db: cfg.db, newHash: newHash, errDel: cfg.errDel}, nil
+	return &MySQLStorage{
+		db:      cfg.db,
+		newHash: newHash,
+		errDel:  cfg.errDel,
+		stsDel:  cfg.stsDel,
+	}, nil
 }
 
 // resultChangedRows tries to tell us if if the record changed. Note that

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -27,5 +27,7 @@ func TestMySQL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	test.TestBasic(t, storage, context.Background())
+	ctx := context.Background()
+	test.TestBasic(t, storage, ctx)
+	test.TestBasicStatus(t, "../test", storage, ctx)
 }

--- a/storage/mysql/schema.00002.sql
+++ b/storage/mysql/schema.00002.sql
@@ -1,2 +1,3 @@
 ALTER TABLE status_errors ADD COLUMN row_count INT DEFAULT 0 NOT NULL;
 ALTER TABLE status_errors ADD INDEX (enrollment_id, row_count);
+-- CREATE TABLE status_reports ... (see schema.sql)

--- a/storage/mysql/schema.00002.sql
+++ b/storage/mysql/schema.00002.sql
@@ -1,0 +1,2 @@
+ALTER TABLE status_errors ADD COLUMN row_count INT DEFAULT 0 NOT NULL;
+ALTER TABLE status_errors ADD INDEX (enrollment_id, row_count);

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -121,11 +121,14 @@ CREATE TABLE status_errors (
     error JSON NOT NULL,
 
     status_id VARCHAR(255) NULL,
+    row_count INT DEFAULT 0 NOT NULL,
 
     INDEX (enrollment_id),
 
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
 
-    INDEX (created_at)
+    INDEX (created_at),
+    INDEX (enrollment_id, row_count)
 );
+

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -142,9 +142,6 @@ CREATE TABLE status_reports (
 
     INDEX (enrollment_id),
 
-    -- beware: we can get close to the maximum index size if our columns are too large
-    UNIQUE (enrollment_id, status_id, row_count),
-
     CHECK (enrollment_id != ''),
     CHECK (status_report != '' AND status_report != 'null'),
 

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -132,3 +132,25 @@ CREATE TABLE status_errors (
     INDEX (enrollment_id, row_count)
 );
 
+CREATE TABLE status_reports (
+    enrollment_id   VARCHAR(255) NOT NULL,
+
+    status_report JSON,
+
+    status_id VARCHAR(255) NULL,
+    row_count INT DEFAULT 0 NOT NULL,
+
+    INDEX (enrollment_id),
+
+    -- beware: we can get close to the maximum index size if our columns are too large
+    UNIQUE (enrollment_id, status_id, row_count),
+
+    CHECK (enrollment_id != ''),
+    CHECK (status_report != '' AND status_report != 'null'),
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+
+    INDEX (created_at),
+    INDEX (enrollment_id, row_count)
+);

--- a/storage/status.go
+++ b/storage/status.go
@@ -1,6 +1,11 @@
 package storage
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+var ErrStatusReportNotFound = errors.New("status report not found")
 
 type StatusError struct {
 	Path      string      `json:"path"`
@@ -14,4 +19,29 @@ type StatusValue struct {
 	Value     string    `json:"value"`
 	Timestamp time.Time `json:"timestamp"`
 	StatusID  string    `json:"status_id,omitempty"`
+}
+
+// StoredStatusReport represents a stored status report by StoreDeclarationStatus.
+type StoredStatusReport struct {
+	Raw       []byte    // the raw JSON bytes of the status report
+	Timestamp time.Time // the date the status report was saved
+	StatusID  string    // optional unique identifier of report. defined when report was saved.
+	Index     int       // optional "index" for this enrollment's status reports.
+}
+
+// StatusReportQuery specifies search criteria for finding specific status reports for enrollments.
+type StatusReportQuery struct {
+	EnrollmentID string
+	StatusID     *string
+	Index        *int
+}
+
+// Valid performs basic sanity checks for querying for status reports.
+func (q StatusReportQuery) Valid() error {
+	if q.EnrollmentID == "" {
+		return errors.New("missing enrollment ID")
+	} else if (q.StatusID == nil || *q.StatusID == "") && q.Index == nil {
+		return errors.New("status ID and index cannot both be empty")
+	}
+	return nil
 }

--- a/storage/status.go
+++ b/storage/status.go
@@ -6,9 +6,12 @@ type StatusError struct {
 	Path      string      `json:"path"`
 	Error     interface{} `json:"error"`
 	Timestamp time.Time   `json:"timestamp"`
+	StatusID  string      `json:"status_id,omitempty"`
 }
 
 type StatusValue struct {
-	Path  string `json:"path"`
-	Value string `json:"value"`
+	Path      string    `json:"path"`
+	Value     string    `json:"value"`
+	Timestamp time.Time `json:"timestamp"`
+	StatusID  string    `json:"status_id,omitempty"`
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3,6 +3,8 @@ package storage
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/jessepeterson/kmfddm/ddm"
 )
@@ -170,9 +172,41 @@ type StatusValuesRetriever interface {
 	RetrieveStatusValues(ctx context.Context, enrollmentIDs []string, pathPrefix string) (map[string][]StatusValue, error)
 }
 
+// StoredStatusReport represents a stored status report by StoreDeclarationStatus.
+type StoredStatusReport struct {
+	Raw       []byte    // the raw JSON bytes of the status report
+	Timestamp time.Time // the date the status report was saved
+	StatusID  string    // optional unique identifier of report. defined when report was saved.
+	Index     int       // optional "index" for this enrollment's status reports.
+}
+
+// StatusReportQuery specifies search criteria for finding specific status reports for enrollments.
+type StatusReportQuery struct {
+	EnrollmentID string
+	StatusID     *string
+	Index        *int
+}
+
+// Valid performs basic sanity checks for querying for status reports.
+func (q StatusReportQuery) Valid() error {
+	if q.EnrollmentID == "" {
+		return errors.New("missing enrollment ID")
+	} else if (q.StatusID == nil || *q.StatusID == "") && q.Index == nil {
+		return errors.New("status ID and index cannot both be empty")
+	}
+	return nil
+}
+
+var ErrStatusReportNotFound = errors.New("status report not found")
+
+type StatusReportRetriever interface {
+	RetrieveStatusReport(ctx context.Context, q StatusReportQuery) (*StoredStatusReport, error)
+}
+
 // StatusAPIStorage are storage interfaces related to retrieving status channel data.
 type StatusAPIStorage interface {
 	StatusDeclarationsRetriever
 	StatusErrorsRetriever
 	StatusValuesRetriever
+	StatusReportRetriever
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3,8 +3,6 @@ package storage
 
 import (
 	"context"
-	"errors"
-	"time"
 
 	"github.com/jessepeterson/kmfddm/ddm"
 )
@@ -171,33 +169,6 @@ type StatusValuesRetriever interface {
 	// RetrieveStatusErrors retrieves the collected errors for enrollmentIDs.
 	RetrieveStatusValues(ctx context.Context, enrollmentIDs []string, pathPrefix string) (map[string][]StatusValue, error)
 }
-
-// StoredStatusReport represents a stored status report by StoreDeclarationStatus.
-type StoredStatusReport struct {
-	Raw       []byte    // the raw JSON bytes of the status report
-	Timestamp time.Time // the date the status report was saved
-	StatusID  string    // optional unique identifier of report. defined when report was saved.
-	Index     int       // optional "index" for this enrollment's status reports.
-}
-
-// StatusReportQuery specifies search criteria for finding specific status reports for enrollments.
-type StatusReportQuery struct {
-	EnrollmentID string
-	StatusID     *string
-	Index        *int
-}
-
-// Valid performs basic sanity checks for querying for status reports.
-func (q StatusReportQuery) Valid() error {
-	if q.EnrollmentID == "" {
-		return errors.New("missing enrollment ID")
-	} else if (q.StatusID == nil || *q.StatusID == "") && q.Index == nil {
-		return errors.New("status ID and index cannot both be empty")
-	}
-	return nil
-}
-
-var ErrStatusReportNotFound = errors.New("status report not found")
 
 type StatusReportRetriever interface {
 	RetrieveStatusReport(ctx context.Context, q StatusReportQuery) (*StoredStatusReport, error)

--- a/storage/test/status.go
+++ b/storage/test/status.go
@@ -21,7 +21,7 @@ type statusStorage interface {
 const statusFile1 = "testdata/status.1st.json"
 const statusFile2 = "testdata/status.D0.error.json"
 const statusFileID1 = "go.test.A047820F-FC6B-4104-BED0-466876D82BB8"
-const statusFileID2 = "go.test.D0463AF6-D0BF-5D06-BBBC-4A9A1386D613-2"
+const statusFileID2 = "go.test.D0463AF6-D0BF-5D06-BBBC-4A9A1386D613"
 
 const testDecl2 = `{
     "Type": "com.apple.configuration.management.test",

--- a/storage/test/status.go
+++ b/storage/test/status.go
@@ -20,8 +20,8 @@ type statusStorage interface {
 
 const statusFile1 = "testdata/status.1st.json"
 const statusFile2 = "testdata/status.D0.error.json"
-const statusFileID1 = "A047820F-FC6B-4104-BED0-466876D82BB8"
-const statusFileID2 = "D0463AF6-D0BF-5D06-BBBC-4A9A1386D613"
+const statusFileID1 = "A047820F-FC6B-4104-BED0-466876D82BB8-1"
+const statusFileID2 = "D0463AF6-D0BF-5D06-BBBC-4A9A1386D613-2"
 
 const testDecl2 = `{
     "Type": "com.apple.configuration.management.test",
@@ -50,6 +50,7 @@ func TestBasicStatus(t *testing.T, pathToDDMTestdata string, storage statusStora
 	if err != nil {
 		t.Fatal(err)
 	}
+	status.ID = "TestBasicStatus-StatusID1"
 
 	err = storage.StoreDeclarationStatus(ctx, statusFileID1, status)
 	if err != nil {
@@ -83,6 +84,7 @@ func TestBasicStatus(t *testing.T, pathToDDMTestdata string, storage statusStora
 	if err != nil {
 		t.Fatal(err)
 	}
+	status.ID = "TestBasicStatus-StatusID2"
 
 	// we have to setup and enable a declaration for it to show up in our declaration status
 

--- a/tools/api-status-report-get-last.sh
+++ b/tools/api-status-report-get-last.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+URL="${BASE_URL}/v1/status-report/$1?index=0"
+
+curl \
+    $CURL_OPTS \
+    -u kmfddm:$API_KEY \
+    "$URL"


### PR DESCRIPTION
* **Store (and later retrieve) entire status reports** when DDM clients send them. See the new storage options for ways to limit the number of them stored.
* **Propagate a Status Report identifier** through to the storage backends for linking/tracking which status report the declaration status, errors, and values came from. Resolves #1.
  * This status ID is also logged as well as reported back when querying the API for declaration, error, values, and of course reports.
  * Additionally add the modification time of errors and values (which correspond to the timestamp the status report was sent at) returned from the API.
  * The status ID comes from the Trace ID of the original HTTP request the status report came in on.
* Add `-storage-options` flag for specifying backend options. Currently only options for MySQL exist.
  * See the new Operations Guide for specific options (namely the `delete_errors` and `delete_status_reports` options)
* Begin work on the Operations Guide. For now include documentation on KMFDDM's command-line switches.
* Ability to limit the number of saved errors in the MySQL backend per enrollment ID. Use the `delete_errors` option with the `-storage-options` switch. Default is still to save unlimited. A similar option exists for the (new) saved status reports.
* Add new tool for querying the last status report of an enrollment ID: `./tools/api-status-report-get-last.sh`.
* Update OpenAPI docs to include these changes.