### PR TITLE
storage API for reading mod time of a declaration

### DIFF
--- a/storage/file/declarations.go
+++ b/storage/file/declarations.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/jessepeterson/kmfddm/ddm"
 )
@@ -140,6 +141,13 @@ func (s *File) readDeclarationFile(declarationID string) (*ddm.Declaration, erro
 		return nil, fmt.Errorf("parsing declaration: %w", err)
 	}
 	return d, nil
+}
+
+// RetrieveDeclarationModTime retrieves the last modification time of the declaration.
+// See also the storage package for documentation on the storage interfaces.
+func (s *File) RetrieveDeclarationModTime(ctx context.Context, declarationID string) (time.Time, error) {
+	fi, err := os.Stat(s.declarationFilename(declarationID))
+	return fi.ModTime(), err
 }
 
 // DeleteDeclaration deletes a declaration by its ID.

--- a/storage/mysql/declarations.go
+++ b/storage/mysql/declarations.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jessepeterson/kmfddm/ddm"
 )
@@ -127,6 +128,16 @@ WHERE
 		err = rows.Err()
 	}
 	return
+}
+
+// RetrieveDeclarationModTime retrieves the last modification time of the declaration.
+// See also the storage package for documentation on the storage interfaces.
+func (s *MySQLStorage) RetrieveDeclarationModTime(ctx context.Context, declarationID string) (time.Time, error) {
+	var dbTimestamp string
+	if err := s.db.QueryRowContext(ctx, "SELECT updated_at FROM declarations WHERE identifier = ? LIMIT 1;", declarationID).Scan(&dbTimestamp); err != nil {
+		return time.Time{}, err
+	}
+	return time.Parse(mysqlTimeFormat, dbTimestamp)
 }
 
 // DeleteDeclaration deletes a declaration and returns whether it was deleted or already existed.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3,6 +3,7 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"github.com/jessepeterson/kmfddm/ddm"
 )
@@ -33,6 +34,8 @@ type DeclarationDeleter interface {
 type DeclarationAPIRetriever interface {
 	// RetrieveDeclaration retrieves a declaration from storage.
 	RetrieveDeclaration(ctx context.Context, declarationID string) (*ddm.Declaration, error)
+	// RetrieveDeclarationModTime retrieves the last modification time of the declaration.
+	RetrieveDeclarationModTime(ctx context.Context, declarationID string) (time.Time, error)
 }
 
 type EnrollmentIDRetriever interface {

--- a/storage/test/declarations.go
+++ b/storage/test/declarations.go
@@ -37,6 +37,13 @@ func testStoreDeclaration(t *testing.T, storage storage.DeclarationAPIStorage, c
 	if have, want := decl2.Type, decl.Type; have != want {
 		t.Errorf("have %q; want %q", have, want)
 	}
+	modTime, err := storage.RetrieveDeclarationModTime(ctx, decl.Identifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modTime.IsZero() {
+		t.Error("declaration mod time is zero")
+	}
 	changed, err := storage.StoreDeclaration(ctx, decl2)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Create this interface method ...

```go
	// RetrieveDeclarationModTime retrieves the last modification time of the declaration.
	RetrieveDeclarationModTime(ctx context.Context, declarationID string) (time.Time, error)
```

... and the implementations for the file and mysql backends. Include a test. Resolves #43.