### PR TITLE
Retrieve declarations and remove sets at storage.

### DIFF
--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -128,3 +128,28 @@ func (s *MySQLStorage) singleStringColumn(ctx context.Context, sql string, args 
 	}
 	return strs, err
 }
+
+func (s *MySQLStorage) RetrieveAllDeclarationIDs(ctx context.Context) (map[string]string, error) {
+    rows, err := s.db.QueryContext(ctx, `SELECT declaration_identifier, set_name FROM set_declarations`)
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+
+    ids := make(map[string]string)
+    for rows.Next() {
+        var id, setName string
+        if err := rows.Scan(&id, &setName); err != nil {
+            return nil, err
+        }
+        ids[id] = setName
+    }
+
+    return ids, rows.Err()
+}
+
+// RemoveSet removes a set from the database.
+func (s *MySQLStorage) RemoveSet(ctx context.Context, setName string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM set_declarations WHERE set_name = ?`, setName)
+	return err
+}


### PR DESCRIPTION
This adds two new methods to the MySQLStorage class in the kmfddm project. The first method, `RetrieveAllDeclarationIDs`, retrieves all the declaration IDs and their corresponding set names from the `set_declarations` table in the database. The second method, `RemoveSet`, deletes a set from the database by executing a `DELETE` query on the `set_declaration` table. These methods will be useful in the future for managing sets in the SQL storage.
