### PR TITLE
Add removing declarations from a set.

### DIFF
--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -128,3 +128,28 @@ func (s *MySQLStorage) singleStringColumn(ctx context.Context, sql string, args 
 	}
 	return strs, err
 }
+
+func (s *MySQLStorage) RetrieveAllDeclarationIDs(ctx context.Context) (map[string]string, error) {
+    rows, err := s.db.QueryContext(ctx, `SELECT declaration_identifier, set_name FROM set_declarations`)
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+
+    ids := make(map[string]string)
+    for rows.Next() {
+        var id, setName string
+        if err := rows.Scan(&id, &setName); err != nil {
+            return nil, err
+        }
+        ids[id] = setName
+    }
+
+    return ids, rows.Err()
+}
+
+// RemoveSet removes a set from the database.
+func (s *MySQLStorage) RemoveSet(ctx context.Context, setName string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM set_declarations WHERE set_name = ?`, setName)
+	return err
+}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -128,28 +128,3 @@ func (s *MySQLStorage) singleStringColumn(ctx context.Context, sql string, args 
 	}
 	return strs, err
 }
-
-func (s *MySQLStorage) RetrieveAllDeclarationIDs(ctx context.Context) (map[string]string, error) {
-    rows, err := s.db.QueryContext(ctx, `SELECT declaration_identifier, set_name FROM set_declarations`)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
-
-    ids := make(map[string]string)
-    for rows.Next() {
-        var id, setName string
-        if err := rows.Scan(&id, &setName); err != nil {
-            return nil, err
-        }
-        ids[id] = setName
-    }
-
-    return ids, rows.Err()
-}
-
-// RemoveSet removes a set from the database.
-func (s *MySQLStorage) RemoveSet(ctx context.Context, setName string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM set_declarations WHERE set_name = ?`, setName)
-	return err
-}

--- a/storage/mysql/sets.go
+++ b/storage/mysql/sets.go
@@ -61,3 +61,19 @@ func (s *MySQLStorage) RetrieveSets(ctx context.Context) ([]string, error) {
 		`SELECT DISTINCT set_name FROM set_declarations;`,
 	)
 }
+
+// RemoveDeclarationsFromSet removes all declarations associated with a set.
+// See also the storage package for documentation on the storage interfaces.
+func (s *MySQLStorage) RemoveDeclarationsFromSet(ctx context.Context, setName string) (bool, error) {
+	result, err := s.db.ExecContext(
+		ctx, `
+DELETE FROM set_declarations
+WHERE
+    set_name = ?;`,
+		setName,
+	)
+	if err != nil {
+		return false, err
+	}
+	return resultChangedRows(result)
+}


### PR DESCRIPTION
This function is designed to remove all declarations associated with a specific set, effectively clearing any links between the set and its declarations without specifying individual declaration identifiers. `RemoveDeclarationsFromSet` operates at a broader level, targeting all declarations associated with a set.

**setName**: The name of the set from which all declarations are to be removed.

Use `RemoveAllDeclarationsFromSet` when you need to completely clear a set of all its associated declarations, which might be useful in scenarios like resetting the set's configuration or prior to deleting the set itself.
