### PR TITLE
dissociate all sets from enrollment

### DIFF
--- a/cmd/kmfddm/main.go
+++ b/cmd/kmfddm/main.go
@@ -224,6 +224,12 @@ func main() {
 				"DELETE",
 			)
 
+			mux.Handle(
+				"/v1/enrollment-sets-all/sets/:id",
+				apihttp.DeleteAllEnrollmentSetsHandler(store, nanoNotif, logger.With(logkeys.Handler, "delete-all-enrollment-sets")),
+				"DELETE",
+			)
+
 			// declarations sets
 			mux.Handle(
 				"/v1/declaration-sets/:id",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -248,6 +248,28 @@ paths:
         - $ref: '#/components/parameters/setNameInQuery'
     parameters:
       - $ref: '#/components/parameters/enrollmentID'
+  /v1/enrollment-sets-all/{id}:
+    delete:
+      description: Dissociate all sets from enrollment ID.
+      tags:
+        - enrollments
+      security:
+        - basicAuth: []
+      responses:
+        '204':
+          $ref: '#/components/responses/DissociationChanged'
+        '304':
+          $ref: '#/components/responses/DissociationUnchanged'
+        '401':
+           $ref: '#/components/responses/UnauthorizedError'
+        '400':
+           $ref: '#/components/responses/JSONBadRequest'
+        '500':
+           $ref: '#/components/responses/JSONError'
+      parameters:
+        - $ref: '#/components/parameters/noNotify'
+    parameters:
+      - $ref: '#/components/parameters/enrollmentID'
   /v1/declaration-sets/{id}:
     get:
       description: Retrieve the list of sets that a declaration is associated with.

--- a/storage/mysql/enrollments.go
+++ b/storage/mysql/enrollments.go
@@ -66,6 +66,17 @@ func qAndP(params []string) (r string, p []interface{}) {
 	return
 }
 
+// RemoveAllEnrollmentSets dissociates enrollment ID from any sets.
+// If any associations are removed true is returned.
+// It should not be an error if no associations exist.
+func (s *MySQLStorage) RemoveAllEnrollmentSets(ctx context.Context, enrollmentID string) (bool, error) {
+	r, err := s.q.RemoveAllEnrollmentSets(ctx, enrollmentID)
+	if err != nil {
+		return false, err
+	}
+	return resultChangedRows(r)
+}
+
 // RetrieveEnrollmentIDs retrieves enrollment IDs.
 // See also the storage package for documentation on the storage interfaces.
 func (s *MySQLStorage) RetrieveEnrollmentIDs(ctx context.Context, declarations []string, sets []string, ids []string) ([]string, error) {

--- a/storage/mysql/query.sql
+++ b/storage/mysql/query.sql
@@ -11,3 +11,9 @@ FROM
         ON sd.set_name = es.set_name
 WHERE
     es.enrollment_id = ?;
+
+-- name: RemoveAllEnrollmentSets :execresult
+DELETE FROM
+    enrollment_sets
+WHERE
+    enrollment_id = ?;

--- a/storage/mysql/sqlc/query.sql.go
+++ b/storage/mysql/sqlc/query.sql.go
@@ -7,6 +7,7 @@ package sqlc
 
 import (
 	"context"
+	"database/sql"
 )
 
 const getManifestItems = `-- name: GetManifestItems :many
@@ -51,4 +52,15 @@ func (q *Queries) GetManifestItems(ctx context.Context, enrollmentID string) ([]
 		return nil, err
 	}
 	return items, nil
+}
+
+const removeAllEnrollmentSets = `-- name: RemoveAllEnrollmentSets :execresult
+DELETE FROM
+    enrollment_sets
+WHERE
+    enrollment_id = ?
+`
+
+func (q *Queries) RemoveAllEnrollmentSets(ctx context.Context, enrollmentID string) (sql.Result, error) {
+	return q.db.ExecContext(ctx, removeAllEnrollmentSets, enrollmentID)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -123,6 +123,11 @@ type EnrollmentSetRemover interface {
 	// If the association is removed true is returned.
 	// It should not be an error if the association does not exist.
 	RemoveEnrollmentSet(ctx context.Context, enrollmentID, setName string) (bool, error)
+
+	// RemoveAllEnrollmentSets dissociates enrollment ID from any sets.
+	// If any associations are removed true is returned.
+	// It should not be an error if no associations exist.
+	RemoveAllEnrollmentSets(ctx context.Context, enrollmentID string) (bool, error)
 }
 
 // EnrollmentSetStorage are storage interfaces related to MDM enrollment IDs.

--- a/storage/test/enrollments.go
+++ b/storage/test/enrollments.go
@@ -165,4 +165,57 @@ func testEnrollments(t *testing.T, store myStorage, ctx context.Context, d *ddm.
 		t.Error("error should be ErrDeclarationNotFound")
 	}
 
+	// associate again
+	changed, err := store.StoreEnrollmentSet(ctx, enrollmentID, setName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := changed, true; have != want {
+		t.Errorf("changed: have: %v, want: %v", have, want)
+	}
+
+	// verify 1 ref
+	setNames, err = store.RetrieveEnrollmentSets(ctx, enrollmentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := len(setNames), 1; have != want {
+		t.Errorf("len(setName) have: %v, want: %v", have, want)
+	} else {
+		if have, want := setNames[0], setName; have != want {
+			t.Errorf("setNames[0] have: %v, want: %v", have, want)
+		}
+	}
+
+	// remove all sets associated with enrollmentID
+	changed, err = store.RemoveAllEnrollmentSets(ctx, enrollmentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := changed, true; have != want {
+		t.Errorf("changed: have: %v, want: %v", have, want)
+	}
+
+	// verify no ref
+	setNames, err = store.RetrieveEnrollmentSets(ctx, enrollmentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := len(setNames), 0; have != want {
+		t.Errorf("len(setName) have: %v, want: %v", have, want)
+	}
+
+	// remove all sets associated with enrollmentID again (to check changed status)
+	changed, err = store.RemoveAllEnrollmentSets(ctx, enrollmentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := changed, false; have != want {
+		t.Errorf("changed: have: %v, want: %v", have, want)
+	}
 }

--- a/tools/api-enrollment-sets-delete-all.sh
+++ b/tools/api-enrollment-sets-delete-all.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+URL="${BASE_URL}/v1/enrollment-sets-all/$1"
+
+curl \
+    $CURL_OPTS \
+    -u kmfddm:$API_KEY \
+    -X DELETE \
+    -w "Response HTTP Code: %{http_code}\n" \
+    "$URL"


### PR DESCRIPTION
Dissociate all sets that are associated to an enrollment ID. Could e.g. be coupled to `TokenUpdate` messages to clear out any previous set associations at enrollment time.