### PR TITLE
Add auth for nanohub support

### DIFF
--- a/tools/ddm-declaration-items.sh
+++ b/tools/ddm-declaration-items.sh
@@ -2,7 +2,12 @@
 
 URL="${BASE_URL}/declaration-items"
 
+if [ "x$API_USER" = "x" ]; then
+    API_USER="kmfddm"
+fi
+
 curl \
     $CURL_OPTS \
     -H "X-Enrollment-ID: $1" \
+    -u "$API_USER:$API_KEY" \
     "$URL"

--- a/tools/ddm-declaration.sh
+++ b/tools/ddm-declaration.sh
@@ -2,7 +2,12 @@
 
 URL="${BASE_URL}/declaration/$2"
 
+if [ "x$API_USER" = "x" ]; then
+    API_USER="kmfddm"
+fi
+
 curl \
     $CURL_OPTS \
     -H "X-Enrollment-ID: $1" \
+    -u "$API_USER:$API_KEY" \
     "$URL"

--- a/tools/ddm-tokens.sh
+++ b/tools/ddm-tokens.sh
@@ -2,7 +2,12 @@
 
 URL="${BASE_URL}/tokens"
 
+if [ "x$API_USER" = "x" ]; then
+    API_USER="kmfddm"
+fi
+
 curl \
     $CURL_OPTS \
     -H "X-Enrollment-ID: $1" \
+    -u "$API_USER:$API_KEY" \
     "$URL"


### PR DESCRIPTION
Because nanohub now requires auth for everything, adding it to these three scripts as well.