### PR TITLE
fix(mysql): recycle pooled connections to avoid stale idle conns

### DIFF
--- a/cmd/kmfddm/storage.go
+++ b/cmd/kmfddm/storage.go
@@ -6,6 +6,7 @@ import (
 	"hash"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jessepeterson/kmfddm/logkeys"
 	"github.com/jessepeterson/kmfddm/storage"
@@ -90,6 +91,22 @@ func setupMySQLStorage(dsn string, options map[string]string, logger log.Logger)
 			}
 			opts = append(opts, mysql.WithStatusReportDeletion(uint(n)))
 			logger.Debug(logkeys.Message, reportDeleteOption, logkeys.GenericCount, int(n))
+		case "conn_max_lifetime":
+			const connMaxLifetimeOption = "connection max lifetime option"
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for %s: %w", connMaxLifetimeOption, err)
+			}
+			opts = append(opts, mysql.WithConnMaxLifetime(d))
+			logger.Debug(logkeys.Message, connMaxLifetimeOption, "duration", d.String())
+		case "conn_max_idle_time":
+			const connMaxIdleTimeOption = "connection max idle time option"
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for %s: %w", connMaxIdleTimeOption, err)
+			}
+			opts = append(opts, mysql.WithConnMaxIdleTime(d))
+			logger.Debug(logkeys.Message, connMaxIdleTimeOption, "duration", d.String())
 		default:
 			return nil, fmt.Errorf("invalid option: %q", k)
 		}

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -101,8 +101,14 @@ Options are specified as a comma-separated list of "key=value" pairs. The mysql 
   * This option sets the maximum number of errors to keep in the database per enrollment ID. A default of zero means to store unlimited errors in the database for each enrollment.
 * `delete_status_reports=N`
   * This option sets the maximum number of errors to keep in the database per enrollment ID. A default of zero means to store unlimited errors in the database for each enrollment.
+* `conn_max_lifetime=duration`
+  * This option sets the maximum amount of time a pooled connection may be reused. The value is a [Go duration string](https://pkg.go.dev/time#ParseDuration) such as `30s`, `3m`, or `1h`. It defaults to `3m`. A value of `0` keeps connections forever.
+* `conn_max_idle_time=duration`
+  * This option sets the maximum amount of time a pooled connection may sit idle before it is closed. The value is a duration string, as above. It defaults to `1m`. A value of `0` never closes connections due to idle time.
 
 *Example:* `-storage mysql -storage-dsn kmfddm:kmfddm/mymdmdb -storage-options delete_errors=20,delete_status_reports=5`
+
+*Example:* `-storage mysql -storage-dsn kmfddm:kmfddm/mymdmdb -storage-options conn_max_lifetime=30s,conn_max_idle_time=15s`
 
 #### in-memory storage backend
 

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -13,14 +13,16 @@ import (
 
 const mysqlTimeFormat = "2006-01-02 15:04:05"
 
-// Recycle pooled connections well before the shortest idle timeout in the
-// network path (the istio-proxy sidecar reaps idle TCP connections at ~1h,
-// Aurora's wait_timeout is longer). Without this, database/sql hands out
-// long-idle connections that the far end has already closed, producing
-// "broken pipe" writes and "closing bad idle connection: EOF" errors.
+// Default connection pool recycling. Pooled connections are recycled well
+// before the shortest idle timeout in the network path (the istio-proxy
+// sidecar reaps idle TCP connections at ~1h, Aurora's wait_timeout is longer).
+// Without this, database/sql hands out long-idle connections that the far end
+// has already closed, producing "broken pipe" writes and "closing bad idle
+// connection: EOF" errors. Override per-deployment with WithConnMaxLifetime /
+// WithConnMaxIdleTime when the path's idle timeout differs.
 const (
-	connMaxLifetime = 3 * time.Minute
-	connMaxIdleTime = 1 * time.Minute
+	defaultConnMaxLifetime = 3 * time.Minute
+	defaultConnMaxIdleTime = 1 * time.Minute
 )
 
 // MySQLStorage implements a MySQL storage backend.
@@ -34,12 +36,14 @@ type MySQLStorage struct {
 }
 
 type config struct {
-	driver string
-	dsn    string
-	db     *sql.DB
-	errDel uint
-	stsDel uint
-	noSts  bool
+	driver          string
+	dsn             string
+	db              *sql.DB
+	errDel          uint
+	stsDel          uint
+	noSts           bool
+	connMaxLifetime time.Duration
+	connMaxIdleTime time.Duration
 }
 
 type Option func(*config)
@@ -89,13 +93,35 @@ func WithoutStatusReports() Option {
 	}
 }
 
+// WithConnMaxLifetime sets the maximum amount of time a connection may be
+// reused. It should be shorter than the shortest idle timeout in the network
+// path to the database. A non-positive value keeps connections forever.
+func WithConnMaxLifetime(d time.Duration) Option {
+	return func(c *config) {
+		c.connMaxLifetime = d
+	}
+}
+
+// WithConnMaxIdleTime sets the maximum amount of time a connection may be idle
+// before it is closed. A non-positive value never closes connections due to
+// idle time.
+func WithConnMaxIdleTime(d time.Duration) Option {
+	return func(c *config) {
+		c.connMaxIdleTime = d
+	}
+}
+
 // New creates and initializes a new MySQL storage backend.
 // New attempts to Ping the database after opening to verify connectivity.
 func New(newHash func() hash.Hash, opts ...Option) (*MySQLStorage, error) {
 	if newHash == nil {
 		panic("nil hasher")
 	}
-	cfg := config{driver: "mysql"}
+	cfg := config{
+		driver:          "mysql",
+		connMaxLifetime: defaultConnMaxLifetime,
+		connMaxIdleTime: defaultConnMaxIdleTime,
+	}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -106,8 +132,8 @@ func New(newHash func() hash.Hash, opts ...Option) (*MySQLStorage, error) {
 			return nil, err
 		}
 	}
-	cfg.db.SetConnMaxLifetime(connMaxLifetime)
-	cfg.db.SetConnMaxIdleTime(connMaxIdleTime)
+	cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
+	cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -6,11 +6,22 @@ import (
 	"database/sql"
 	"fmt"
 	"hash"
+	"time"
 
 	"github.com/jessepeterson/kmfddm/storage/mysql/sqlc"
 )
 
 const mysqlTimeFormat = "2006-01-02 15:04:05"
+
+// Recycle pooled connections well before the shortest idle timeout in the
+// network path (the istio-proxy sidecar reaps idle TCP connections at ~1h,
+// Aurora's wait_timeout is longer). Without this, database/sql hands out
+// long-idle connections that the far end has already closed, producing
+// "broken pipe" writes and "closing bad idle connection: EOF" errors.
+const (
+	connMaxLifetime = 3 * time.Minute
+	connMaxIdleTime = 1 * time.Minute
+)
 
 // MySQLStorage implements a MySQL storage backend.
 type MySQLStorage struct {
@@ -95,6 +106,8 @@ func New(newHash func() hash.Hash, opts ...Option) (*MySQLStorage, error) {
 			return nil, err
 		}
 	}
+	cfg.db.SetConnMaxLifetime(connMaxLifetime)
+	cfg.db.SetConnMaxIdleTime(connMaxIdleTime)
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -13,17 +13,14 @@ import (
 
 const mysqlTimeFormat = "2006-01-02 15:04:05"
 
-// Default connection pool recycling. Pooled connections are recycled well
-// before the shortest idle timeout in the network path (the istio-proxy
-// sidecar reaps idle TCP connections at ~1h, Aurora's wait_timeout is longer).
-// Without this, database/sql hands out long-idle connections that the far end
-// has already closed, producing "broken pipe" writes and "closing bad idle
-// connection: EOF" errors. Override per-deployment with WithConnMaxLifetime /
-// WithConnMaxIdleTime when the path's idle timeout differs.
-const (
-	defaultConnMaxLifetime = 3 * time.Minute
-	defaultConnMaxIdleTime = 1 * time.Minute
-)
+// Connection pool recycling is left at database/sql's defaults unless
+// configured. Pooled connections should be recycled well before the shortest
+// idle timeout in the network path (the istio-proxy sidecar reaps idle TCP
+// connections at ~1h, Aurora's wait_timeout is longer). Without recycling,
+// database/sql hands out long-idle connections that the far end has already
+// closed, producing "broken pipe" writes and "closing bad idle connection:
+// EOF" errors. Set WithConnMaxLifetime / WithConnMaxIdleTime per-deployment to
+// enable recycling for the path's idle timeout.
 
 // MySQLStorage implements a MySQL storage backend.
 type MySQLStorage struct {
@@ -36,14 +33,16 @@ type MySQLStorage struct {
 }
 
 type config struct {
-	driver          string
-	dsn             string
-	db              *sql.DB
-	errDel          uint
-	stsDel          uint
-	noSts           bool
-	connMaxLifetime time.Duration
-	connMaxIdleTime time.Duration
+	driver             string
+	dsn                string
+	db                 *sql.DB
+	errDel             uint
+	stsDel             uint
+	noSts              bool
+	connMaxLifetime    time.Duration
+	connMaxLifetimeSet bool
+	connMaxIdleTime    time.Duration
+	connMaxIdleTimeSet bool
 }
 
 type Option func(*config)
@@ -99,6 +98,7 @@ func WithoutStatusReports() Option {
 func WithConnMaxLifetime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxLifetime = d
+		c.connMaxLifetimeSet = true
 	}
 }
 
@@ -108,6 +108,7 @@ func WithConnMaxLifetime(d time.Duration) Option {
 func WithConnMaxIdleTime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxIdleTime = d
+		c.connMaxIdleTimeSet = true
 	}
 }
 
@@ -118,9 +119,7 @@ func New(newHash func() hash.Hash, opts ...Option) (*MySQLStorage, error) {
 		panic("nil hasher")
 	}
 	cfg := config{
-		driver:          "mysql",
-		connMaxLifetime: defaultConnMaxLifetime,
-		connMaxIdleTime: defaultConnMaxIdleTime,
+		driver: "mysql",
 	}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -132,8 +131,12 @@ func New(newHash func() hash.Hash, opts ...Option) (*MySQLStorage, error) {
 			return nil, err
 		}
 	}
-	cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
-	cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
+	if cfg.connMaxLifetimeSet {
+		cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
+	}
+	if cfg.connMaxIdleTimeSet {
+		cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
+	}
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The MySQL storage pool was opened with no lifetime tuning, so database/sql retained idle connections indefinitely. The istio-proxy sidecar reaps idle TCP connections at ~1h (Aurora wait_timeout is longer), so kmfddm reused already-closed connections, producing "write: broken pipe" and "closing bad idle connection: EOF" errors.

Set SetConnMaxLifetime(3m) and SetConnMaxIdleTime(1m), both well under the proxy idle timeout, so the pool recycles connections before anything in the path can kill them.

seeing many after a long period of running:

```
[mysql] 2026/07/27 17:55:03 packets.go:155 write tcp kmfddmhost:36660->aurorasql:3306: write: broken pipe
[mysql] 2026/07/27 17:55:03 connection.go:706 closing bad idle connection: EOF
[mysql] 2026/07/27 17:55:03 packets.go:155 write tcp kmfddm:60760->aurorasql:3306: write: broken pipe
```